### PR TITLE
support non_blocking attribute for symbols

### DIFF
--- a/example/add_test.ts
+++ b/example/add_test.ts
@@ -2,11 +2,12 @@ import {
   add,
   add2,
   OptionStruct,
+  sleep,
   test_mixed,
   test_mixed_order,
   test_serde,
 } from "./bindings/bindings.ts";
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assert, assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
 Deno.test({
   name: "add#test",
@@ -45,10 +46,21 @@ Deno.test({
 });
 
 Deno.test({
-  name: "test_options",
+  name: "test_options#test",
   fn: () => {
     let opts: OptionStruct = { maybe: " " };
     opts.maybe = null;
     opts.maybe = undefined;
+  },
+});
+
+Deno.test({
+  name: "sleep#test",
+  fn: async () => {
+    const ms = 100;
+    const start = performance.now();
+    const promise = sleep(ms).then(() => assert(start >= ms));
+    assert(performance.now() - start < ms);
+    await promise;
   },
 });

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -3,47 +3,71 @@ import { Plug } from "https://deno.land/x/plug@0.4.0/mod.ts";
 const encode = (s: string) => new TextEncoder().encode(s);
 const opts = {
   name: "add",
-  url: "target/debug"
+  url: "target/debug",
 };
 const _lib = await Plug.prepare(opts, {
-  add: { parameters: [ "i32", "i32" ], result: "i32" }, test_mixed: { parameters: [ "isize", "buffer", "usize" ], result: "i32" }, test_serde: { parameters: [ "buffer", "usize" ], result: "u8" }, add2: { parameters: [ "buffer", "usize" ], result: "i32" }, test_mixed_order: { parameters: [ "i32", "buffer", "usize", "i32" ], result: "i32" } });
-export type OptionStruct = {
-    maybe: string | undefined | null;
+  add: { parameters: ["i32", "i32"], result: "i32", nonblocking: false },
+  sleep: { parameters: ["u64"], result: "void", nonblocking: true },
+  test_serde: {
+    parameters: ["buffer", "usize"],
+    result: "u8",
+    nonblocking: false,
+  },
+  add2: { parameters: ["buffer", "usize"], result: "i32", nonblocking: false },
+  test_mixed_order: {
+    parameters: ["i32", "buffer", "usize", "i32"],
+    result: "i32",
+    nonblocking: false,
+  },
+  test_mixed: {
+    parameters: ["isize", "buffer", "usize"],
+    result: "i32",
+    nonblocking: false,
+  },
+});
+export type MyStruct = {
+  arr: Array<string>;
 };
 /**
-  * Doc comment for `Input` struct.
-  * ...testing multiline
-  **/
+ * Doc comment for `Input` struct.
+ * ...testing multiline
+ */
 export type Input = {
   /**
-  * Doc comments get 
-  * transformed to JS doc
-  * comments.
-  **/
+   * Doc comments get
+   * transformed to JS doc
+   * comments.
+   */
   a: number;
   b: number;
 };
-export type MyStruct = {
-    arr: Array<string>;
+export type OptionStruct = {
+  maybe: string | undefined | null;
 };
-export function add(a0: number,a1: number) {
-  
-  return _lib.symbols.add(a0, a1) as number
+export function add(a0: number, a1: number) {
+  return _lib.symbols.add(a0, a1) as number;
 }
-export function test_mixed(a0: number,a1: Input) {
-  const a1_buf = encode(JSON.stringify(a1));
-  return _lib.symbols.test_mixed(a0, a1_buf, a1_buf.byteLength) as number
+export function sleep(a0: number) {
+  return _lib.symbols.sleep(a0) as Promise<null>;
 }
 export function test_serde(a0: MyStruct) {
   const a0_buf = encode(JSON.stringify(a0));
-  return _lib.symbols.test_serde(a0_buf, a0_buf.byteLength) as number
+  return _lib.symbols.test_serde(a0_buf, a0_buf.byteLength) as number;
 }
 export function add2(a0: Input) {
   const a0_buf = encode(JSON.stringify(a0));
-  return _lib.symbols.add2(a0_buf, a0_buf.byteLength) as number
+  return _lib.symbols.add2(a0_buf, a0_buf.byteLength) as number;
 }
-export function test_mixed_order(a0: number,a1: Input,a2: number) {
+export function test_mixed_order(a0: number, a1: Input, a2: number) {
   const a1_buf = encode(JSON.stringify(a1));
-  return _lib.symbols.test_mixed_order(a0, a1_buf, a1_buf.byteLength, a2) as number
+  return _lib.symbols.test_mixed_order(
+    a0,
+    a1_buf,
+    a1_buf.byteLength,
+    a2,
+  ) as number;
 }
- 
+export function test_mixed(a0: number, a1: Input) {
+  const a1_buf = encode(JSON.stringify(a1));
+  return _lib.symbols.test_mixed(a0, a1_buf, a1_buf.byteLength) as number;
+}

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -58,3 +58,10 @@ fn test_serde(s: MyStruct) -> u8 {
 struct OptionStruct {
   maybe: Option<String>,
 }
+
+// Test non_blocking
+#[deno_bindgen(non_blocking)]
+fn sleep(ms: u64) {
+  std::thread::sleep(std::time::Duration::from_millis(ms));
+}
+


### PR DESCRIPTION
Closes #6 

Mark symbols to run on a dedicated blocking thread using the `non_blocking` attribute.
```rust
#[deno_bindgen(non_blocking)]
fn sleep(ms: u64) {
  let duration = std::time::Duration::from_millis(ms);
  std::thread::sleep(duration);
}
```