### PR TITLE
Upgrade to Deno 1.18.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.17
+          deno-version: 1.18.2
 
       - name: Install rust
         uses: hecrj/setup-rust-action@v1

--- a/README.md
+++ b/README.md
@@ -181,4 +181,3 @@ The `deno_bindgen` CLI tool provides the following flags:
   ```shell
   deno_bindgen -- --features "cool_stuff"
   ```
-

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -1,5 +1,5 @@
 // Auto-generated with deno_bindgen
-import { CachePolicy, prepare } from "https://deno.land/x/plug@0.4.1/plug.ts"
+import { CachePolicy, prepare } from "https://deno.land/x/plug@0.5.1/plug.ts"
 function encode(v: string | Uint8Array): Uint8Array {
   if (typeof v !== "string") return v
   return new TextEncoder().encode(v)
@@ -7,7 +7,7 @@ function encode(v: string | Uint8Array): Uint8Array {
 function decode(v: Uint8Array): string {
   return new TextDecoder().decode(v)
 }
-function read_pointer(v: any): Uint8Array {
+function readPointer(v: any): Uint8Array {
   const ptr = new Deno.UnsafePointerView(v as Deno.UnsafePointer)
   const lengthBe = new Uint8Array(4)
   const view = new DataView(lengthBe.buffer)
@@ -89,11 +89,26 @@ const _lib = await prepare(opts, {
     nonblocking: false,
   },
 })
+export type TagAndContent =
+  | { key: "A"; value: { b: number } }
+  | { key: "C"; value: { d: number } }
 export type OptionStruct = {
   maybe: string | undefined | null
 }
+export type TestLifetimes = {
+  text: string
+}
 export type MyStruct = {
   arr: Array<string>
+}
+export type TestLifetimeEnums = {
+  Text: {
+    _text: string
+  }
+}
+export type TestReservedField = {
+  type: number
+  ref: number
 }
 export type PlainEnum =
   | {
@@ -103,13 +118,6 @@ export type PlainEnum =
   }
   | "b"
   | "c"
-export type TestReservedField = {
-  type: number
-  ref: number
-}
-export type TestLifetimes = {
-  text: string
-}
 /**
  * Doc comment for `Input` struct.
  * ...testing multiline
@@ -123,118 +131,115 @@ export type Input = {
   a: number
   b: number
 }
-export type TestLifetimeEnums = {
-  Text: {
-    _text: string
-  }
-}
 export type TestLifetimeWrap = {
   _a: TestLifetimeEnums
 }
-export type TagAndContent =
-  | { key: "A"; value: { b: number } }
-  | { key: "C"; value: { d: number } }
 export function add(a0: number, a1: number) {
-  let result = _lib.symbols.add(a0, a1) as number
+  let rawResult = _lib.symbols.add(a0, a1)
+  const result = rawResult
   return result
 }
 export function add2(a0: Input) {
   const a0_buf = encode(JSON.stringify(a0))
-  let result = _lib.symbols.add2(a0_buf, a0_buf.byteLength) as number
+  let rawResult = _lib.symbols.add2(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function sleep(a0: number) {
-  let result = _lib.symbols.sleep(a0) as Promise<null>
+  let rawResult = _lib.symbols.sleep(a0)
+  const result = rawResult
   return result
 }
 export function test_buf(a0: Uint8Array) {
   const a0_buf = encode(a0)
-  let result = _lib.symbols.test_buf(a0_buf, a0_buf.byteLength) as number
+  let rawResult = _lib.symbols.test_buf(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_buffer_return(a0: Uint8Array) {
   const a0_buf = encode(a0)
-  let result = _lib.symbols.test_buffer_return(
-    a0_buf,
-    a0_buf.byteLength,
-  ) as Uint8Array
-  result = read_pointer(result)
+  let rawResult = _lib.symbols.test_buffer_return(a0_buf, a0_buf.byteLength)
+  const result = readPointer(rawResult)
   return result
 }
 export function test_buffer_return_async(a0: Uint8Array) {
   const a0_buf = encode(a0)
-  let result = _lib.symbols.test_buffer_return_async(
+  let rawResult = _lib.symbols.test_buffer_return_async(
     a0_buf,
     a0_buf.byteLength,
-  ) as Promise<Uint8Array>
-  result = result.then(read_pointer)
+  )
+  const result = rawResult.then(readPointer)
   return result
 }
 export function test_lifetime(a0: TestLifetimes) {
   const a0_buf = encode(JSON.stringify(a0))
-  let result = _lib.symbols.test_lifetime(a0_buf, a0_buf.byteLength) as number
+  let rawResult = _lib.symbols.test_lifetime(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_manual_ptr() {
-  let result = _lib.symbols.test_manual_ptr() as Uint8Array
-  result = read_pointer(result)
+  let rawResult = _lib.symbols.test_manual_ptr()
+  const result = readPointer(rawResult)
   return result
 }
 export function test_manual_ptr_async() {
-  let result = _lib.symbols.test_manual_ptr_async() as Promise<Uint8Array>
-  result = result.then(read_pointer)
+  let rawResult = _lib.symbols.test_manual_ptr_async()
+  const result = rawResult.then(readPointer)
   return result
 }
 export function test_mixed(a0: number, a1: Input) {
   const a1_buf = encode(JSON.stringify(a1))
-  let result = _lib.symbols.test_mixed(a0, a1_buf, a1_buf.byteLength) as number
+  let rawResult = _lib.symbols.test_mixed(a0, a1_buf, a1_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_mixed_order(a0: number, a1: Input, a2: number) {
   const a1_buf = encode(JSON.stringify(a1))
-  let result = _lib.symbols.test_mixed_order(
+  let rawResult = _lib.symbols.test_mixed_order(
     a0,
     a1_buf,
     a1_buf.byteLength,
     a2,
-  ) as number
+  )
+  const result = rawResult
   return result
 }
 export function test_mut_buf(a0: Uint8Array) {
   const a0_buf = encode(a0)
-  let result = _lib.symbols.test_mut_buf(a0_buf, a0_buf.byteLength) as null
+  let rawResult = _lib.symbols.test_mut_buf(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_output() {
-  let result = _lib.symbols.test_output() as Uint8Array
-  result = read_pointer(result)
+  let rawResult = _lib.symbols.test_output()
+  const result = readPointer(rawResult)
   return JSON.parse(decode(result)) as Input
 }
 export function test_output_async() {
-  let result = _lib.symbols.test_output_async() as Promise<Uint8Array>
-  result = result.then(read_pointer)
+  let rawResult = _lib.symbols.test_output_async()
+  const result = rawResult.then(readPointer)
   return result.then(r => JSON.parse(decode(r))) as Promise<Input>
 }
 export function test_reserved_field() {
-  let result = _lib.symbols.test_reserved_field() as Uint8Array
-  result = read_pointer(result)
+  let rawResult = _lib.symbols.test_reserved_field()
+  const result = readPointer(rawResult)
   return JSON.parse(decode(result)) as TestReservedField
 }
 export function test_serde(a0: MyStruct) {
   const a0_buf = encode(JSON.stringify(a0))
-  let result = _lib.symbols.test_serde(a0_buf, a0_buf.byteLength) as number
+  let rawResult = _lib.symbols.test_serde(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_str(a0: string) {
   const a0_buf = encode(a0)
-  let result = _lib.symbols.test_str(a0_buf, a0_buf.byteLength) as null
+  let rawResult = _lib.symbols.test_str(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }
 export function test_tag_and_content(a0: TagAndContent) {
   const a0_buf = encode(JSON.stringify(a0))
-  let result = _lib.symbols.test_tag_and_content(
-    a0_buf,
-    a0_buf.byteLength,
-  ) as number
+  let rawResult = _lib.symbols.test_tag_and_content(a0_buf, a0_buf.byteLength)
+  const result = rawResult
   return result
 }

--- a/example/bindings_test.ts
+++ b/example/bindings_test.ts
@@ -14,10 +14,10 @@ import {
   test_mut_buf,
   test_output,
   test_output_async,
+  test_reserved_field,
   test_serde,
   test_str,
   test_tag_and_content,
-  test_reserved_field,
   TestReservedField,
 } from "./bindings/bindings.ts";
 import { assert, assertEquals } from "https://deno.land/std/testing/asserts.ts";
@@ -189,4 +189,3 @@ Deno.test({
     assertEquals(obj.ref, 2);
   },
 });
-


### PR DESCRIPTION
1.18 added type inference which conflicted with deno_bindgen's codegen. This patch lets Deno FFI infer return types.