### PR TITLE
add `--nocache` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ The `deno_bindgen` CLI tool provides the following flags:
   Under the hood this uses [`x/plug`](https://deno.land/x/plug) to fetch and
   cache the artifact.
 
+- Pass `--nocache` to disable artifact caching.
+
 - Flags after `--` will be passed to `cargo build`. Example:
   ```shell
   deno_bindgen -- --features "cool_stuff"

--- a/cli.ts
+++ b/cli.ts
@@ -6,6 +6,7 @@ import { codegen } from "./codegen.ts";
 
 const flags = parse(Deno.args, { "--": true });
 const release = !!flags.release;
+const useCache = ("nocache" in flags) ? false : release; // disable cache with --nocache, otherwise cache only in release mode
 
 const fetchPrefix = typeof flags.release == "string"
   ? flags.release
@@ -41,6 +42,7 @@ async function generate() {
     {
       le: conf.littleEndian,
       release,
+      useCache,
     },
   );
 

--- a/codegen.ts
+++ b/codegen.ts
@@ -92,6 +92,7 @@ type Sig = Record<string, {
 type Options = {
   le?: boolean;
   release?: boolean;
+  useCache?: boolean;
 };
 
 function isTypeDef(p: any) {
@@ -146,7 +147,7 @@ function readPointer(v: any): Uint8Array {
 const opts = {
   name: "${name}",
   url: (new URL("${fetchPrefix}", import.meta.url)).toString(),
-  policy: ${!!options?.release ? "undefined" : "CachePolicy.NONE"},
+  policy: ${options?.useCache ? "undefined" : "CachePolicy.NONE"},
 };
 const _lib = await prepare(opts, {
   ${

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -90,14 +90,14 @@ const _lib = await prepare(opts, {
     nonblocking: false,
   },
 })
-export type TestLifetimeEnums = {
-  Text: {
-    _text: string
+export type PlainEnum =
+  | {
+    a: {
+      _a: string
+    }
   }
-}
-export type TestLifetimes = {
-  text: string
-}
+  | "b"
+  | "c"
 /**
  * Doc comment for `Input` struct.
  * ...testing multiline
@@ -114,27 +114,27 @@ export type Input = {
 export type TestLifetimeWrap = {
   _a: TestLifetimeEnums
 }
-export type TagAndContent =
-  | { key: "A"; value: { b: number } }
-  | { key: "C"; value: { d: number } }
+export type TestLifetimeEnums = {
+  Text: {
+    _text: string
+  }
+}
+export type TestLifetimes = {
+  text: string
+}
+export type TestReservedField = {
+  type: number
+  ref: number
+}
 export type MyStruct = {
   arr: Array<string>
 }
 export type OptionStruct = {
   maybe: string | undefined | null
 }
-export type TestReservedField = {
-  type: number
-  ref: number
-}
-export type PlainEnum =
-  | {
-    a: {
-      _a: string
-    }
-  }
-  | "b"
-  | "c"
+export type TagAndContent =
+  | { key: "A"; value: { b: number } }
+  | { key: "C"; value: { d: number } }
 export function add(a0: number, a1: number) {
   let rawResult = _lib.symbols.add(a0, a1)
   const result = rawResult


### PR DESCRIPTION
related to #57 

This adds a `--nocache` option which can be used alongside `--release` to disable caching.  As far as I can tell, caching is already disabled for development builds, which is why this fix doesn't apply to #57.

I'm using deno_bindgen to build a couple of crates that are painfully slow in debug mode, so I always build them with `deno_bindgen --release`.  The problem was that caching kept my changes from showing up, so I'd have to manually clear the cache before every build.

This solved my problem, but I'm also curious about what the benefit is of caching local artifacts at all.  Network, sure, but if disabling local artifact caching entirely is a good option, this PR is unnecessary.

Thanks for deno_bindgen, it's been awesome, and thanks for humoring me with this PR. :upside_down_face: 