### PR TITLE
[wip] feat: implement "object wraps"

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -38,6 +38,7 @@ async function generate() {
     conf.typeDefs,
     conf.tsTypes,
     conf.symbols,
+    conf.classes,
     {
       le: conf.littleEndian,
       release,

--- a/codegen.ts
+++ b/codegen.ts
@@ -109,6 +109,7 @@ export function codegen(
   decl: TypeDef,
   typescript: Record<string, string>,
   signature: Sig,
+  classes: TypeDef = {}, 
   options?: Options,
 ) {
   signature = Object.keys(signature)
@@ -164,6 +165,17 @@ const _lib = await prepare(opts, {
       ).join(", ")
     } });
 ${Object.keys(decl).map((def) => typescript[def]).join("\n")}
+${Object.keys(classes).map(name => `
+export class ${name} {
+  #ptr = Deno.UnsafePointer;
+  ${Object.keys(classes[name]).map(sig => {
+    const { parameters, result, nonBlocking } = classes[name][sig];
+    return `${sig}(${ parameters.map((p, i) => `a${i}: ${resolveType(decl, p)}`).join(",") }) {
+
+    }`
+  }).join("\n")}
+}
+`).join("\n")}
 ${
       Object.keys(signature).map((sig) => {
         const { parameters, result, nonBlocking } = signature[sig];

--- a/deno_bindgen_macro/src/lib.rs
+++ b/deno_bindgen_macro/src/lib.rs
@@ -3,13 +3,17 @@
 use proc_macro::TokenStream;
 use quote::format_ident;
 use quote::quote;
+use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::io::Write;
 use syn::parse_macro_input;
 use syn::parse_quote;
+use syn::FnArg;
 use syn::ItemFn;
+use syn::ItemImpl;
+use syn::ReturnType;
 
 mod attrs;
 mod derive_fn;
@@ -20,6 +24,7 @@ mod meta;
 use crate::derive_fn::process_function;
 use crate::derive_struct::process_struct;
 use crate::meta::Glue;
+use crate::meta::Symbol;
 use crate::meta::Type;
 
 const METAFILE: &str = "bindings.json";
@@ -211,9 +216,9 @@ pub fn deno_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
       // impl Item
       match syn::parse::<ItemImpl>(input.clone()) {
         Ok(item) => {
-          return process_impl(&mut metadata, item).unwrap();
+          let impl_ = process_impl(&mut metadata, item);
         }
-        _ => {},
+        _ => {}
       };
       let input = syn::parse_macro_input!(input as syn::DeriveInput);
       process_struct(&mut metadata, input.clone()).unwrap();
@@ -230,14 +235,164 @@ pub fn deno_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
   }
 }
 
-fn process_impl(
-  metadata: &mut Glue,
-  item: ItemImpl,
-) {
+fn process_impl(metadata: &mut Glue, item: ItemImpl) {
   assert!(item.trait_.is_none());
-  for item in item.items {
-    syn::ImplItem::Method(impl_method) => {
-      process_func()
+
+  let mut methods = HashMap::new();
+  let name = match *item.self_ty {
+    syn::Type::Path(path) => {
+      let segment = path.path.segments.first().unwrap();
+      segment.ident.to_string()
     }
-    _ => unimplemented!("only methods in impl items")
+    _ => unimplemented!("`impl Type` where type is not a Path"),
+  };
+  for item in item.items {
+    match item {
+      syn::ImplItem::Method(impl_method) => {
+        let params = &impl_method.sig.inputs;
+        let mut parameters = Vec::with_capacity(params.len());
+
+        for param in params.iter() {
+          match param {
+            FnArg::Typed(ref val) => {
+              let val = val.clone();
+              let ty = match *val.ty {
+                syn::Type::Path(ref ty) => {
+                  let segment = ty.path.segments.first().unwrap();
+                  let ident = segment.ident.to_string();
+
+                  match ident.as_str() {
+                    "i8" => Type::I8,
+                    "u8" => Type::U8,
+                    "i16" => Type::I16,
+                    "u16" => Type::U16,
+                    "i32" => Type::I32,
+                    "u32" => Type::U32,
+                    "i64" => Type::I64,
+                    "u64" => Type::U64,
+                    "usize" => Type::Usize,
+                    "isize" => Type::Isize,
+                    _ => {
+                      metadata.type_defs.get(&ident).expect(&format!(
+                        "Type definition not found for `{}` identifier",
+                        &ident,
+                      ));
+
+                      Type::StructEnum { ident }
+                    }
+                  }
+                }
+                syn::Type::Reference(ref ty) => match *ty.elem {
+                  syn::Type::Path(ref ty) => {
+                    let segment = ty.path.segments.first().unwrap();
+                    let ident = segment.ident.to_string();
+
+                    match ident.as_str() {
+                      "str" => Type::Str,
+                      _ => unimplemented!(),
+                    }
+                  }
+                  syn::Type::Slice(ref slice) => match *slice.elem {
+                    syn::Type::Path(ref path) => {
+                      let segment = path.path.segments.first().unwrap();
+                      let ident = segment.ident.to_string();
+
+                      match ident.as_str() {
+                        "u8" => {
+                          if ty.mutability.is_some() {
+                            Type::BufferMut
+                          } else {
+                            Type::Buffer
+                          }
+                        }
+                        _ => unimplemented!(),
+                      }
+                    }
+                    _ => unimplemented!(),
+                  },
+                  _ => unimplemented!(),
+                },
+                _ => unimplemented!(),
+              };
+
+              parameters.push(ty);
+            }
+            _ => unimplemented!(),
+          }
+        }
+
+        let result = match &impl_method.sig.output {
+          ReturnType::Default => Type::Void,
+          ReturnType::Type(_, ref ty) => match ty.as_ref() {
+            syn::Type::Ptr(_) => Type::Ptr,
+            syn::Type::Path(ref ty) => {
+              let segment = ty.path.segments.first().unwrap();
+              let ident = segment.ident.to_string();
+
+              match ident.as_str() {
+                "i8" => Type::I8,
+                "u8" => Type::U8,
+                "i16" => Type::I16,
+                "u16" => Type::U16,
+                "i32" => Type::I32,
+                "u32" => Type::U32,
+                "i64" => Type::I64,
+                "u64" => Type::U64,
+                "usize" => Type::Usize,
+                "isize" => Type::Isize,
+                "f32" => Type::F32,
+                "f64" => Type::F64,
+                // This isn't a &str but i really but
+                // don't want to add another type for just owned strings.
+                "String" => Type::Str,
+                _ => match metadata.type_defs.get(&ident) {
+                  Some(_) => Type::StructEnum { ident },
+                  None => {
+                    panic!("{} return type not supported by Deno FFI", ident)
+                  }
+                },
+              }
+            }
+            syn::Type::Reference(ref ty) => match *ty.elem {
+              syn::Type::Slice(ref slice) => match *slice.elem {
+                syn::Type::Path(ref path) => {
+                  let segment = path.path.segments.first().unwrap();
+                  let ident = segment.ident.to_string();
+
+                  match ident.as_str() {
+                    "u8" => {
+                      if ty.mutability.is_some() {
+                        // https://github.com/denoland/deno_bindgen/issues/39
+                        panic!("Mutable slices are not mutable from JS");
+                      } else {
+                        Type::Buffer
+                      }
+                    }
+                    _ => unimplemented!(),
+                  }
+                }
+                _ => unimplemented!(),
+              },
+              _ => unimplemented!(),
+            },
+            _ => unimplemented!(),
+          },
+        };
+
+        let method_name = impl_method.sig.ident.to_string();
+        let symbol_name = format!("${}_{}", &name, &method_name);
+
+        let symbol = Symbol {
+          parameters,
+          result,
+          non_blocking: false,
+        };
+        metadata.symbols.insert(symbol_name, symbol.clone());
+        methods.insert(method_name, symbol);
+      }
+      _ => unimplemented!("only methods in impl items"),
+    }
   }
+
+  metadata.classes.insert(name, methods);
+}

--- a/deno_bindgen_macro/src/lib.rs
+++ b/deno_bindgen_macro/src/lib.rs
@@ -208,6 +208,13 @@ pub fn deno_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
       })
     }
     Err(_) => {
+      // impl Item
+      match syn::parse::<ItemImpl>(input.clone()) {
+        Ok(item) => {
+          return process_impl(&mut metadata, item).unwrap();
+        }
+        _ => {},
+      };
       let input = syn::parse_macro_input!(input as syn::DeriveInput);
       process_struct(&mut metadata, input.clone()).unwrap();
 
@@ -222,3 +229,15 @@ pub fn deno_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     }
   }
 }
+
+fn process_impl(
+  metadata: &mut Glue,
+  item: ItemImpl,
+) {
+  assert!(item.trait_.is_none());
+  for item in item.items {
+    syn::ImplItem::Method(impl_method) => {
+      process_func()
+    }
+    _ => unimplemented!("only methods in impl items")
+  }

--- a/deno_bindgen_macro/src/meta.rs
+++ b/deno_bindgen_macro/src/meta.rs
@@ -75,4 +75,5 @@ pub struct Glue {
   pub symbols: HashMap<String, Symbol>,
   pub type_defs: HashMap<String, HashMap<String, String>>,
   pub ts_types: HashMap<String, String>,
+  pub classes: HashMap<String, HashMap<String, Symbol>>,
 }


### PR DESCRIPTION
Closes #63 

Rust structs as JavaScript classes. Prior art: `wasm_bindgen` & `napi-rs`.

```rust
pub struct NonSerializable {
  inner: i32,
}

#[deno_bindgen]
impl NonSerializable {
  pub fn add(&mut self, a: i32) {
    self.inner += a;
  }
  
  #[deno_bindgen(constructor)]
  pub fn new() -> Self {
    Self { inner: 0 }
  }
}
```

```ts
import { NonSerializable } from "./bindings/bindings.ts";
const ptr = new NonSerializable();
ptr.add(10)
```