### PR TITLE
fix(codegen): map Rust `HashMap`s as TypeScript `Record`s

### DIFF
--- a/deno_bindgen_macro/src/derive_struct.rs
+++ b/deno_bindgen_macro/src/derive_struct.rs
@@ -265,7 +265,7 @@ fn rs_to_ts(ty: &str) -> &str {
     "str" => "string",
     "f32" => "number",
     "f64" => "number",
-    "HashMap" => "Map",
+    "HashMap" => "Record",
     "Vec" => "Array",
     "HashSet" => "Array",
     "Value" => "any",

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -40,6 +40,7 @@ const _lib = await prepare(opts, {
     result: "pointer",
     nonblocking: true,
   },
+  test_hashmap: { parameters: [], result: "pointer", nonblocking: false },
   test_lifetime: {
     parameters: ["pointer", "usize"],
     result: "usize",
@@ -90,20 +91,8 @@ const _lib = await prepare(opts, {
     nonblocking: false,
   },
 })
-export type TestLifetimeWrap = {
-  _a: TestLifetimeEnums
-}
-export type PlainEnum =
-  | {
-    a: {
-      _a: string
-    }
-  }
-  | "b"
-  | "c"
-export type TestReservedField = {
-  type: number
-  ref: number
+export type TestLifetimes = {
+  text: string
 }
 /**
  * Doc comment for `Input` struct.
@@ -121,19 +110,34 @@ export type Input = {
 export type TagAndContent =
   | { key: "A"; value: { b: number } }
   | { key: "C"; value: { d: number } }
-export type TestLifetimes = {
-  text: string
+export type WithRecord = {
+  my_map: Record<string, string>
 }
-export type OptionStruct = {
-  maybe: string | undefined | null
+export type TestReservedField = {
+  type: number
+  ref: number
 }
 export type MyStruct = {
   arr: Array<string>
 }
+export type TestLifetimeWrap = {
+  _a: TestLifetimeEnums
+}
+export type PlainEnum =
+  | {
+    a: {
+      _a: string
+    }
+  }
+  | "b"
+  | "c"
 export type TestLifetimeEnums = {
   Text: {
     _text: string
   }
+}
+export type OptionStruct = {
+  maybe: string | undefined | null
 }
 export function add(a0: number, a1: number) {
   let rawResult = _lib.symbols.add(a0, a1)
@@ -171,6 +175,11 @@ export function test_buffer_return_async(a0: Uint8Array) {
   )
   const result = rawResult.then(readPointer)
   return result
+}
+export function test_hashmap() {
+  let rawResult = _lib.symbols.test_hashmap()
+  const result = readPointer(rawResult)
+  return JSON.parse(decode(result)) as WithRecord
 }
 export function test_lifetime(a0: TestLifetimes) {
   const a0_buf = encode(JSON.stringify(a0))

--- a/example/bindings_test.ts
+++ b/example/bindings_test.ts
@@ -6,6 +6,7 @@ import {
   test_buf,
   test_buffer_return,
   test_buffer_return_async,
+  test_hashmap,
   test_lifetime,
   test_manual_ptr,
   test_manual_ptr_async,
@@ -20,6 +21,7 @@ import {
   test_str_ret,
   test_tag_and_content,
   TestReservedField,
+  WithRecord,
 } from "./bindings/bindings.ts";
 import { assert, assertEquals } from "https://deno.land/std/testing/asserts.ts";
 
@@ -195,5 +197,12 @@ Deno.test({
   name: "test_str_ret#test",
   fn: () => {
     assertEquals(test_str_ret(), "🦕");
+  },
+});
+
+Deno.test({
+  name: "test_hashmap#test",
+  fn: () => {
+    assertEquals(test_hashmap(), { my_map: { "key": "value" } } as WithRecord);
   },
 });

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,4 +1,5 @@
 use deno_bindgen::deno_bindgen;
+use std::collections::HashMap;
 
 // Test "primitives"
 #[deno_bindgen]
@@ -206,3 +207,17 @@ fn test_reserved_field() -> TestReservedField {
 fn test_str_ret() -> String {
   String::from("🦕")
 } 
+
+#[deno_bindgen]
+pub struct WithRecord {
+  my_map: HashMap<String, String>,
+}
+
+#[deno_bindgen]
+fn test_hashmap() -> WithRecord {
+  let mut map = HashMap::new();
+  map.insert("key".to_string(), "value".to_string());
+  WithRecord {
+    my_map: map,
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_bindgen/issues/54