### PR TITLE
use OUT_DIR env variable if defined as prefix path

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -2,6 +2,7 @@
 
 import { ensureDir } from "https://deno.land/std@0.132.0/fs/ensure_dir.ts";
 import { parse } from "https://deno.land/std@0.132.0/flags/mod.ts";
+import { join } from "https://deno.land/std@0.132.0/path/mod.ts";
 import { codegen } from "./codegen.ts";
 
 const flags = parse(Deno.args, { "--": true });
@@ -10,6 +11,8 @@ const release = !!flags.release;
 const fetchPrefix = typeof flags.release == "string"
   ? flags.release
   : "../target/" + (release ? "release" : "debug");
+
+const metafile = join(Deno.env.get("OUT_DIR") || "", "bindings.json");
 
 async function build() {
   const cmd = ["cargo", "build"];
@@ -23,7 +26,7 @@ let source = null;
 async function generate() {
   let conf;
   try {
-    conf = JSON.parse(await Deno.readTextFile("bindings.json"));
+    conf = JSON.parse(await Deno.readTextFile(metafile));
   } catch (_) {
     // Nothing to update.
     return;
@@ -44,16 +47,16 @@ async function generate() {
     },
   );
 
-  await Deno.remove("bindings.json");
+  await Deno.remove(metafile);
 }
 
 try {
-  await Deno.remove("bindings.json");
+  await Deno.remove(metafile);
 } catch (e) {
   // no op
 }
 
-const status = await build().catch((_) => Deno.removeSync("bindings.json"));
+const status = await build().catch((_) => Deno.removeSync(metafile));
 if (status?.success || typeof flags.release == "string") {
   await generate();
   if (source) {


### PR DESCRIPTION
use OUT_DIR env variable if defined as prefix path for location of temporary bindings.json file. fixes #72