### PR TITLE
fix: deno_bindgen does not work properly on Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,28 +4,32 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ windows-latest, macos-latest,  ubuntu-latest ]
+        toolchain: [nightly]
+        deno_version: [1.25.0]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-
+      - uses: actions/checkout@v2
+      - name: Cache toolchain
+        uses: Swatinem/rust-cache@v1
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.toolchain }}
+            override: true
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.25.0
-
-      - name: Install rust
-        uses: hecrj/setup-rust-action@v1
+          deno-version: ${{ matrix.deno_version }}
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: nightly
-
-      - name: Install clippy and rustfmt
-        run: |
-          rustup component add clippy
-          rustup component add rustfmt
+            toolchain: ${{ matrix.toolchain }}
+            override: true
+            components: rustfmt, clippy
       - name: Build
         run: cargo build --locked --release
-
       - name: Build Example
         run: |
           cd example

--- a/cli.ts
+++ b/cli.ts
@@ -9,7 +9,10 @@ import { codegen } from "./codegen.ts";
 const flags = parse(Deno.args, { "--": true });
 const release = !!flags.release;
 
-const metafile = join(Deno.env.get("OUT_DIR") || await findRelativeTarget(), "bindings.json");
+const metafile = join(
+  Deno.env.get("OUT_DIR") || await findRelativeTarget(),
+  "bindings.json",
+);
 
 function build() {
   const cmd = ["cargo", "build"];
@@ -39,14 +42,10 @@ async function generate() {
   }
 
   const pkgName = conf.name;
-  const fetchPrefix =
-    typeof flags.release == "string"
-      ? flags.release
-      : join(
-          await findRelativeTarget(),
-          "../target",
-          release ? "release" : "debug"
-        );
+  const fetchPrefix = typeof flags.release == "string"
+    ? flags.release
+    : await findRelativeTarget() + ["../target", release ? "release" : "debug"]
+      .join("/");
 
   source = "// Auto-generated with deno_bindgen\n";
   source += codegen(
@@ -58,7 +57,7 @@ async function generate() {
     {
       le: conf.littleEndian,
       release,
-    }
+    },
   );
 
   await Deno.remove(metafile);


### PR DESCRIPTION
fix https://github.com/denoland/deno_bindgen/issues/91

When deno_bindgen run on Windows, the `fetchPrefix` should be `..\target\debug`.
But `\` escapes the next characters, so the final `fetchPrefix` will be `\..argetdebug`.
