### PR TITLE
fix(cli): bug when a relative path ends with double dot

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -45,10 +45,11 @@ async function generate() {
   if (!cargoTarget) cargoTarget = "../target";
 
   const pkgName = conf.name;
-  const fetchPrefix = typeof flags.release == "string"
-    ? flags.release
-    : await findRelativeTarget() + [cargoTarget, release ? "release" : "debug"]
-      .join("/");
+  const fetchPrefix = typeof flags.release == "string" ? flags.release : join(
+    await findRelativeTarget(),
+    cargoTarget,
+    release ? "release" : "debug",
+  );
 
   source = "// Auto-generated with deno_bindgen\n";
   source += codegen(


### PR DESCRIPTION
Fixes a bug when using the cli from within a `packages/x` directory in a cargo workspace.

`findRelativeTarget()` can return `../..` which is added (not joined) with `../target`, hence creating a quadruple dot path. `../..../target`, which results in an error when trying to run.

```
error: Uncaught (in promise) CacheError: /[...]/repo_root/packages/<package-name>/..../target/debug/lib<package-name>.so is not valid.
    throw new CacheError(`${path} is not valid.`);
```