### PR TITLE
fix: release url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,15 @@ jobs:
             components: rustfmt, clippy
       - name: Build
         run: cargo build --locked --release
-      - name: Build Example
+      - name: Build Example (debug)
+        working-directory: ./example
         run: |
-          cd example
           deno run -A ../cli.ts
-          deno test --no-check -A --unstable
+          deno test -A --unstable
+      - name: Build Example (release)
+        working-directory: ./example
+        shell: bash
+        run: |
+          rm -rf target
+          deno run -A ../cli.ts --release=../target/release
+          deno test -A --unstable

--- a/codegen.ts
+++ b/codegen.ts
@@ -166,23 +166,14 @@ import { dlopen, FetchOptions } from "https://deno.land/x/plug@1.0.1/mod.ts";
 let uri = url.toString();
 if (!uri.endsWith("/")) uri += "/";
 
-let darwin: string | { aarch64: string; x86_64: string } = uri + "lib${name}.dylib";
-
-if (url.protocol !== "file:") {
-  // Assume that remote assets follow naming scheme
-  // for each macOS artifact.
-  darwin = {
-    aarch64: uri + "lib${name}_arm64.dylib",
-    x86_64: uri + "lib${name}.dylib",
-  }
-}
+let darwin: string | { aarch64: string; x86_64: string } = uri;
 
 const opts: FetchOptions = {
   name: "${name}",
   url: {
     darwin,
-    windows: uri + "${name}.dll",
-    linux: uri + "lib${name}.so",
+    windows: uri,
+    linux: uri,
   },
   cache: ${!!options?.release ? '"use"' : '"reloadAll"'},
 };

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -19,30 +19,20 @@ function readPointer(v: any): Uint8Array {
   return buf
 }
 
-const url = new URL("../target/debug", import.meta.url)
+const url = new URL("../target/release", import.meta.url)
 
 import { dlopen, FetchOptions } from "https://deno.land/x/plug@1.0.1/mod.ts"
 let uri = url.toString()
 if (!uri.endsWith("/")) uri += "/"
 
 let darwin: string | { aarch64: string; x86_64: string } = uri
-  + "libdeno_bindgen_test.dylib"
-
-if (url.protocol !== "file:") {
-  // Assume that remote assets follow naming scheme
-  // for each macOS artifact.
-  darwin = {
-    aarch64: uri + "libdeno_bindgen_test_arm64.dylib",
-    x86_64: uri + "libdeno_bindgen_test.dylib",
-  }
-}
 
 const opts: FetchOptions = {
   name: "deno_bindgen_test",
   url: {
     darwin,
-    windows: uri + "deno_bindgen_test.dll",
-    linux: uri + "libdeno_bindgen_test.so",
+    windows: uri,
+    linux: uri,
   },
   cache: "use",
 }


### PR DESCRIPTION
This PR tries to fix the url for fetching the dynamic lib when `--release` flag is passed to `deno_bindgen` cli