### PR TITLE
fix: cannot fetch darwin arm64 binary

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -175,6 +175,11 @@ const opts: FetchOptions = {
     windows: uri,
     linux: uri,
   },
+  suffixes: {
+    darwin: {
+      aarch64: "_arm64",
+    },
+  },
   cache: ${!!options?.release ? '"use"' : '"reloadAll"'},
 };
 const { symbols } = await dlopen(opts, {

--- a/example/bindings/bindings.ts
+++ b/example/bindings/bindings.ts
@@ -34,6 +34,11 @@ const opts: FetchOptions = {
     windows: uri,
     linux: uri,
   },
+  suffixes: {
+    darwin: {
+      aarch64: "_arm64",
+    },
+  },
   cache: "use",
 }
 const { symbols } = await dlopen(opts, {


### PR DESCRIPTION
Fixed incompatibility with M1 Mac release binary name change in v0.8.0 release